### PR TITLE
Add new skin: Dark Plum

### DIFF
--- a/Dark Plum [real].json
+++ b/Dark Plum [real].json
@@ -1,5 +1,6 @@
 //
 // Skin file for Dark Plum [real]
+// Made by Zroxos
 // Copyright 2020 by reFX Audio Software Inc.
 //
 // Do NOT modify this file directly as every time you
@@ -13,10 +14,10 @@
 	// Palette of your own colors that can then be used for the skin
 	"palette": {
 
-		"--primary": "#A51FFF",
+		"--primary": "#BA54FF",
 		"--secondary": "#70f",
 		"--group": "#160024",
-		"--dark": "#11001F"
+		"--dark": "#250047"
 	},
 
 	// Front panel properties
@@ -53,11 +54,11 @@
 			// Dials
 			"dials": {
 
-				"ring": "#370066",
+				"ring": "#4A0083",
 
 				"outline": "#1F0033",
 				"top": "#8800FF",
-				"bottom": "#15006B",
+				"bottom": "#440080",
 
 				"bevel": {
 
@@ -105,11 +106,6 @@
 
 			// Dials
 			"dials": {
-
-				"outline": "#1F0033",
-				"top": "#8800FF",
-				"bottom": "#15006B",
-
 				"bevel": {
 
 					"highlight": "#fff2",

--- a/Dark Plum [real].json
+++ b/Dark Plum [real].json
@@ -1,0 +1,162 @@
+//
+// Skin file for Dark Plum [real]
+// Copyright 2020 by reFX Audio Software Inc.
+//
+// Do NOT modify this file directly as every time you
+// open the reFX cloud-app, it will detect that is has been changed
+// and download it again, overwriting your changes.
+//
+// If you want to make a skin based on this one, copy it under a different
+// name and make changes to the copy.
+//
+{
+	// Palette of your own colors that can then be used for the skin
+	"palette": {
+
+		"--primary": "#A51FFF",
+		"--secondary": "#70f",
+		"--group": "#160024",
+		"--dark": "#11001F"
+	},
+
+	// Front panel properties
+	"panel": {
+
+		// Here we define all colors for the panel
+		"colors": {
+
+			// General
+			"background": "--dark",
+			"label": "--secondary",
+			"accent": "--primary",
+			"shadows": "#000c",
+			"modulated": "#933CFF",
+			"noise": "#0002",
+
+			// Groups
+			"groups": {
+
+				"background": "--group",
+				"label": "--primary",
+
+				"browser": {
+
+					"selected": {
+
+						"text": "--group",
+						"icon": "--group",
+						"number": "--group"
+					}
+				}
+			},
+
+			// Dials
+			"dials": {
+
+				"ring": "#370066",
+
+				"outline": "#1F0033",
+				"top": "#8800FF",
+				"bottom": "#15006B",
+
+				"bevel": {
+
+					"highlight": "#fff2",
+					"shadow": "#0002"
+				},
+
+				"line": "#fff8"
+			}
+		},
+
+		// Here we define panel-dials properties
+		"dial-style": {
+
+			"outline": 1.5,
+			"top-bevel": 1.5,
+			"ring-width": 3,
+			"ring-space": 4,
+			"shadow-size": 0.7,
+			"shadow-distance-y": 0.2,
+			"pointer-space": 3,
+			"pointer-width": 2.5
+		}
+	},
+
+	// Header properties
+	"header": {
+
+		// Here we define all colors for the header
+		"colors": {
+
+			// General
+			"background": "--dark",
+			"label": "--secondary",
+			"accent": "--primary",
+			"shadows": "#0007",
+
+			"groups": {
+
+				"background": "#170029",
+				"label": "#B14DFF",
+				"label-medium": "#7C36B3",
+				"label-dark": "#5B00CC"
+			},
+
+			// Dials
+			"dials": {
+
+				"outline": "#1F0033",
+				"top": "#8800FF",
+				"bottom": "#15006B",
+
+				"bevel": {
+
+					"highlight": "#fff2",
+					"shadow": "#0002"
+				},
+
+				"line": "#fff8"
+			}
+		},
+
+		// Here we define header-dials properties
+		"dial-style": {
+
+			"outline": 1.5
+		},
+
+		// Here we define note-event properties
+		"events": {
+			"note-depth": 0.2,
+			"note-radius": 2,
+			"note-outline": 0.5
+		}
+	},
+
+	// Preview-dial
+	"preview": {
+
+		// Here we define preview-dial properties
+		"dial-style": {
+
+			"outline": 1,
+			"ring-space": 2,	// only for preview-dial: limited to 0-2
+			"ring-width": 0,	// only for preview-dial: limited to 0-2
+			"shadow-size": 0.33,
+			"shadow-distance-y": 0.3
+		}
+	},
+
+	// Here we define the virtual keyboard
+	"keyboard": {
+
+		"colors": {
+			"wheels": "#2A004D",
+			"black-notes": "#B173E6",
+			"white-notes": "#21003D"
+		},
+
+		"realistic": true
+	}
+}


### PR DESCRIPTION
Hi! I made a new skin for Nexus 3. I just found out about the ability to create your own custom skins for the plugin today and I thought it was really exciting. 
This skin that I made is inspired by Nexus 2's Plum skin, used to be one of my favorites :-) I made the entire look more "all-purple"  using different shades of purple colors instead of a black/purple combination.
I inverted the keyboard colors at the bottom to get a look resembling that of some old Pipe Organs with black white keys and white black notes, but with purple shades instead. 
Here's a screenshot: 

![Dark Plum for Nexus 3](https://i.imgur.com/n0jqzX9.png "Dark Plum for Nexus 3")

I kept the [real] tag in the title (not sure what it means) and the reFX copyright header at the top of the file, though I don't know if that's what is preferred.

I've used Nexus for a long time now, and getting my own skin into the plugin would truly be a dream come true. :-) Hope you like it.